### PR TITLE
Configurações de Node Mailer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:4.8-stretch
 
-ENV KONECTY_VERSION 1.0.6
+ENV KONECTY_VERSION 1.0.7
 
 RUN set -x \
  && curl -SLf "https://github.com/Konecty/Konecty/releases/download/$KONECTY_VERSION/Konecty.tar.gz" -o Konecty.tar.gz \

--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ meteor
 - `DEFAULT_SMTP_PASSWORD`: SMTP password for default email sender (**required**)
 - `DEFAULT_SMTP_SECURE`: SMTP secure flag for default email sender
 - `DEFAULT_SMTP_TLS`: SMTP tls flag for default email sender
+- `DEFAULT_SMTP_IGNORE_TLS`: SMTP config `ignoreTLS` for nodemailer, if this is true and secure is false then TLS is not used even if the server supports STARTTLS extension
+- `DEFAULT_SMTP_TLS_REJECT_UNAUTHORIZED`: SMTP config `tls.rejectUnauthorized` for nodemailer, config would open a connection to TLS server with self-signed or invalid TLS certificate
+- `DEFAULT_SMTP_AUTH_METHOD`: SMTP config `authMethod` for nodemailer, defines preferred authentication method, defaults to ‘PLAIN’
+- `DEFAULT_SMTP_DEBUG`: SMTP config `debug` for nodemailer, if set to true, then logs SMTP traffic, otherwise logs only transaction events
 
 ## How to run on Docker
 
 ```
-docker login registry.gitlab.com
-docker run --name kondata -p 3000:3000 --link mongo --env MONGO_URL=mongodb://mongo:27017/konecty --env MONGO_OPLOG_URL=mongodb://mongo:27017/local registry.gitlab.com/konecty/konecty:latest
+docker pull konecty/konecty
+docker run --name kondata -p 3000:3000 --link mongo --env MONGO_URL=mongodb://mongo:27017/konecty --env MONGO_OPLOG_URL=mongodb://mongo:27017/local konecty/konecty
 ```
 
 ## REST API

--- a/packages/konsistent/server/lib/mailConsumer.coffee
+++ b/packages/konsistent/server/lib/mailConsumer.coffee
@@ -192,25 +192,31 @@ mailConsumer.start = ->
 	if not transporters.default? and process.env.DEFAULT_SMTP_HOST? and process.env.DEFAULT_SMTP_PORT? and process.env.DEFAULT_SMTP_USERNAME? and process.env.DEFAULT_SMTP_PASSWORD?
 		defaultSMTPConfig =
 			host: process.env.DEFAULT_SMTP_HOST
-			port: process.env.DEFAULT_SMTP_PORT
+			port: +process.env.DEFAULT_SMTP_PORT
 			auth:
 				user: process.env.DEFAULT_SMTP_USERNAME
 				pass: process.env.DEFAULT_SMTP_PASSWORD
 
 		if process.env.DEFAULT_SMTP_SECURE?
-			defaultSMTPConfig.secure = process.env.DEFAULT_SMTP_SECURE
+			defaultSMTPConfig.secure = process.env.DEFAULT_SMTP_SECURE == 'true'
 
 		if process.env.DEFAULT_SMTP_TLS?
 			defaultSMTPConfig.tls = process.env.DEFAULT_SMTP_TLS
 
 		if process.env.DEFAULT_SMTP_IGNORE_TLS?
-			defaultSMTPConfig.ignoreTLS = process.env.DEFAULT_SMTP_IGNORE_TLS
+			defaultSMTPConfig.ignoreTLS = process.env.DEFAULT_SMTP_IGNORE_TLS == 'true'
 		
-		if process.env.DEFAULT_SMTP_REQUIRE_TLS?
-			defaultSMTPConfig.requireTLS = process.env.DEFAULT_SMTP_REQUIRE_TLS
+		if process.env.DEFAULT_SMTP_TLS_REJECT_UNAUTHORIZED?
+			defaultSMTPConfig.tls =
+				rejectUnauthorized: process.env.DEFAULT_SMTP_TLS_REJECT_UNAUTHORIZED == 'true'
 
+		if process.env.DEFAULT_SMTP_AUTH_METHOD?
+			defaultSMTPConfig.authMethod = process.env.DEFAULT_SMTP_AUTH_METHOD
 		
-
+		if process.env.DEFAULT_SMTP_DEBUG?
+			defaultSMTPConfig.debug = process.env.DEFAULT_SMTP_DEBUG == 'true'
+		
+		console.log "Setup default email server".green
 		transporters.default = nodemailer.createTransport smtpTransport defaultSMTPConfig
 
 	mailConsumer.consume()


### PR DESCRIPTION
Ajuste em Docs e variáveis de ambiente novas:
- `DEFAULT_SMTP_IGNORE_TLS`: SMTP config `ignoreTLS` for nodemailer, if this is true and secure is false then TLS is not used even if the server supports STARTTLS extension
- `DEFAULT_SMTP_TLS_REJECT_UNAUTHORIZED`: SMTP config `tls.rejectUnauthorized` for nodemailer, config would open a connection to TLS server with self-signed or invalid TLS certificate
- `DEFAULT_SMTP_AUTH_METHOD`: SMTP config `authMethod` for nodemailer, defines preferred authentication method, defaults to ‘PLAIN’
- `DEFAULT_SMTP_DEBUG`: SMTP config `debug` for nodemailer, if set to true, then logs SMTP traffic, otherwise logs only transaction events
