### PR TITLE
Remove authTokenNs from set-cookie response header

### DIFF
--- a/server/routes/rest/auth/authApi.js
+++ b/server/routes/rest/auth/authApi.js
@@ -16,12 +16,7 @@ app.get('/rest/auth/loginByUrl/:ns/:sessionId', function(req, res) {
   const cookieMaxAge = get(namespace, 'sessionExpirationInSeconds', 2592000);
 
   // Set cookie with session id
-  res.set(
-    'set-cookie',
-    `_authTokenNs=${req.params.ns}; _authTokenId=${
-      req.params.sessionId
-    }; ${domain} Version=1; Path=/; Max-Age=${cookieMaxAge.toString()}`
-  );
+  res.set('set-cookie', `_authTokenId=${req.params.sessionId}; ${domain} Version=1; Path=/; Max-Age=${cookieMaxAge.toString()}`);
 
   // Redirect to system
   return res.redirect('/');


### PR DESCRIPTION
`set-cookie` header only sets 1 cookie on most recent browsers, thus nullifying the tokenId being passed as second cookie.
Removing the tokenNs from the header, the id is set and the user can log in just fine.