### PR TITLE
Use default meta values for type and status on process/submit

### DIFF
--- a/server/methods/process.js
+++ b/server/methods/process.js
@@ -1245,12 +1245,16 @@ Meteor.registerMethod('process:contact', 'withUser', function(request, options) 
 			createRequest.ignoreAutoNumber = true;
 		}
 
-		// default data
+        const { fields: { status, type } } = Meteor.call('document', { document: 'Contact' });
+
+		// Use defaultValue field from status and type metas
 		if (!contactData.status) {
-			createRequest.data.status = 'Lead';
+		    if (status && status.defaultValue)
+			    createRequest.data.status = status.defaultValue;
 		}
 		if (!contactData.type) {
-			createRequest.data.type = ['Cliente'];
+		    if (type && type.defaultValue)
+			    createRequest.data.type = type.maxSelected > 1 || type.isList === true ? [].concat(type.defaultValue) : type.defaultValue;
 		}
 
 		// console.log '[data:create] ->'.yellow, JSON.stringify createRequest, null, '  '


### PR DESCRIPTION
Get the default meta values for the `type` and `status` fields when it isn`t present on the process/submit contact creation.