### PR TITLE
Fix: validate search regex to prevent breaking

### DIFF
--- a/server/methods/data.coffee
+++ b/server/methods/data.coffee
@@ -404,6 +404,11 @@ Meteor.registerMethod 'data:find:byLookup', 'withUser', 'withAccessForDocument',
 
 	if not model?
 		return new Meteor.Error 'internal-error', "[#{request.document}] Document #{field.document} does not exists"
+	
+	try
+		new RegExp(request.search)
+	catch e
+		return new Meteor.Error 'internal-error', "Invalid search [#{request.search}]"
 
 	query = {}
 	fields =


### PR DESCRIPTION
Validate search regex before querying mongo to prevent the error below

![Screenshot from 2023-01-13 12-18-07](https://user-images.githubusercontent.com/31394736/212406508-8117ede0-765c-47e8-9b2b-119f8165fbfa.png)
