### PR TITLE
Fix: remove buggy wrapAsync call on Konsistent

### DIFF
--- a/packages/konsistent/server/imports/index.js
+++ b/packages/konsistent/server/imports/index.js
@@ -1,7 +1,7 @@
 /*
  * @TODO test sincrony
  */
-import { isEmpty, bind, isObject, isString, uniq, intersection, isArray, compact, has, get, size, keys } from 'lodash';
+import { bind, compact, get, has, intersection, isArray, isEmpty, isObject, isString, keys, size, uniq } from 'lodash';
 import { parse } from 'mongodb-uri';
 
 Konsistent = {};
@@ -627,12 +627,9 @@ Konsistent.History.updateRelationReference = function (metaName, relation, looku
 
 		pipeline.push(group);
 
-		// Wrap aggregate method into an async metero's method
-		const aggregate = Meteor.wrapAsync(bind(collection.aggregate, collection));
-
 		// Try to execute agg and log error if fails
 		try {
-			const resultsCursor = aggregate(pipeline, { cursor: { batchSize: 1 } });
+			const resultsCursor = collection.aggregate(pipeline, { cursor: { batchSize: 1 } });
 			const aggregateToArray = Meteor.wrapAsync(resultsCursor.toArray, resultsCursor);
 
 			let result = aggregateToArray();


### PR DESCRIPTION
Removed `meteor.wrapAsync` call on `collection.aggregate` as the aggregate function isn't async when returning the mongo cursor.

It was triggering the following error **_MongoInvalidArgumentError: Method "collection.aggregate()" accepts at most two arguments_** as the wrapAsync call attaches a callback function as an additional parameter on the function call.

That bug was silently preventing the Konsistent from updating relations on documents