### PR TITLE
fix: clear projection path collision on Mongo find

### DIFF
--- a/packages/konutils/package.js
+++ b/packages/konutils/package.js
@@ -5,7 +5,7 @@ Package.describe({
   git: ''
 });
 
-Package.onUse(function(api) {
+Package.onUse(function (api) {
   api.use('ecmascript');
   api.use('mongo');
   api.use('coffeescript');
@@ -30,6 +30,7 @@ Package.onUse(function(api) {
 });
 
 Npm.depends({
+  lodash: '4.17.10',
   moment: '2.18.1',
   'moment-timezone': '0.5.13',
   request: '2.88.0'

--- a/packages/konutils/server/filterUtils.coffee
+++ b/packages/konutils/server/filterUtils.coffee
@@ -1,4 +1,5 @@
 crypto = require 'crypto'
+_ = Npm.require 'lodash'
 
 ###
 rest/data/OK Activity/find
@@ -336,3 +337,12 @@ filterUtils.parseDynamicData = (filter, keyword, data) ->
 				parseConditions condition
 
 	return filter
+
+# Deduplicate projection keys so as to not trigger Mongo Path Collision error, implemented after version 4.4
+# ex: { group: 1, group._id: 1, _user: 1 } => { group: 1, _user: 1 }
+filterUtils.clearProjectionPathCollision = (projection) ->
+	fields = Object.entries projection
+	cleaned = _.uniqBy fields, (field) ->
+		field[0].split('.')[0]
+	
+	return _.fromPairs cleaned

--- a/server/methods/data.coffee
+++ b/server/methods/data.coffee
@@ -141,7 +141,7 @@ Meteor.registerMethod 'data:find:all', 'withUser', 'withAccessForDocument', (req
 	options =
 		limit: parseInt request.limit
 		skip: parseInt request.start
-		fields: fields
+		fields: filterUtils.clearProjectionPathCollision fields
 		sort: sort
 
 	if _.isNaN(options.limit) or not options.limit?
@@ -343,7 +343,7 @@ Meteor.registerMethod 'data:find:byId', 'withUser', 'withAccessForDocument', (re
 							fields[conditionField] = 1
 
 	options =
-		fields: fields
+		fields: filterUtils.clearProjectionPathCollision fields
 
 	data = model.findOne query, options
 
@@ -527,7 +527,7 @@ Meteor.registerMethod 'data:find:byLookup', 'withUser', 'withAccessForDocument',
 	options =
 		limit: parseInt request.limit
 		skip: parseInt request.start
-		fields: fields
+		fields: filterUtils.clearProjectionPathCollision fields
 		sort: sort
 
 	if _.isNaN(options.limit) or not options.limit?


### PR DESCRIPTION
Deduplicate projection keys on mongo find to avoid Path Collision error, implemented on version 4.4 forward. 

The error: 
![image](https://github.com/konecty/Konecty/assets/31394736/972ef394-9c4e-4505-87a1-0856738d9e58)

Occurs when the projection keys (see image above) lead to the same object being referenced more than once. 
Ex: `{ "group": 1, "group._id": 1 }`
