### PR TITLE
feat: add list view route

### DIFF
--- a/imports/list-view/index.ts
+++ b/imports/list-view/index.ts
@@ -1,0 +1,39 @@
+import sortBy from 'lodash/sortBy';
+
+import { MetaObjectCollection } from '/imports/model/MetaObject';
+import { DocumentListSchema } from '/imports/model/DocumentList';
+import { logger } from '/imports/utils/logger';
+import { MetaObjectType } from '/imports/types/metadata';
+
+export async function listView(document: string, id: string) {
+	const list = await MetaObjectCollection.findOne<MetaObjectType>({ type: 'list', document: document, name: id, menuSorter: { $nin: [-1, -2, -3] } });
+
+	if (list?.type != 'list') {
+		throw new Error(`List ${document}/${id} not found`);
+	}
+
+	const columnsArray = Object.entries(list.columns).map(([, value]) => value);
+
+	const listColumns = sortBy(columnsArray, ['sort', 'name']);
+
+	const listViewResult = DocumentListSchema.safeParse({
+		...list,
+		document,
+		columns: listColumns,
+		label: list.label['en'],
+		plurals: list.plurals['en'],
+	});
+
+	if (listViewResult.success === false) {
+		logger.error(
+			{
+				list,
+				error: listViewResult.error,
+			},
+			'Error parsing menu item',
+		);
+		return null;
+	}
+
+	return listViewResult.data;
+}

--- a/imports/list-view/index.ts
+++ b/imports/list-view/index.ts
@@ -30,7 +30,7 @@ export async function listView(document: string, id: string) {
 				list,
 				error: listViewResult.error,
 			},
-			'Error parsing menu item',
+			`Error parsing list view ${document}/${id}`,
 		);
 		return null;
 	}

--- a/imports/menu/main/index.ts
+++ b/imports/menu/main/index.ts
@@ -74,23 +74,6 @@ export async function mainMenu(user: User) {
 		return itemPath;
 	};
 
-	const getformatedColumns = (
-		columns: Record<
-			string,
-			{
-				name: string;
-				linkedField: string;
-				visible: boolean;
-				minWidth?: number | undefined;
-				sort?: number | undefined;
-			}
-		>,
-	) => {
-		const columnsArray = Object.entries(columns).map(([, value]) => value);
-
-		return sortBy(columnsArray, ['sort', 'name']);
-	};
-
 	const mainMenu = menuItens.reduce((acc, item, index) => {
 		const document = getDocumentName(item);
 
@@ -113,7 +96,6 @@ export async function mainMenu(user: User) {
 				name: item.name,
 				type: item.type,
 				document,
-				columns: getformatedColumns(item.columns),
 				menuSorter: item.menuSorter ?? 999 + index,
 				icon: item.icon,
 			});
@@ -202,7 +184,6 @@ export async function mainMenu(user: User) {
 				itemPath,
 				MenuItemSchema.parse({
 					...preferenceItem,
-					columns: getformatedColumns(preferenceItem.columns),
 					_id: item._id,
 					name: originalItemName,
 					isPreference: true,

--- a/imports/model/DocumentList.ts
+++ b/imports/model/DocumentList.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const DocumentListSchema = z.object({
+	_id: z.string(),
+	name: z.string(),
+	document: z.string().optional(),
+	label: z.string(),
+	plurals: z.string(),
+	loadDataAtOpen: z.boolean().optional(),
+	columns: z.array(
+		z.object({
+			name: z.string(),
+			linkField: z.string().optional(),
+			visible: z.boolean().optional(),
+			minWidth: z.number().optional(),
+		}),
+	),
+	refreshRate: z.object({
+		options: z.array(z.number()),
+		default: z.number(),
+	}),
+	rowsPerPage: z.object({
+		options: z.array(z.number()),
+		default: z.number(),
+	}),
+	sorters: z.array(
+		z.object({
+			term: z.string(),
+			direction: z.enum(['asc', 'desc']),
+		}),
+	),
+	view: z.string().default('Default'),
+});
+
+export type DocumentList = z.infer<typeof DocumentListSchema>;

--- a/imports/model/Menu.ts
+++ b/imports/model/Menu.ts
@@ -5,16 +5,6 @@ export const MenuItemSchema = z.object({
 	name: z.string(),
 	type: z.string(),
 	document: z.string().optional(),
-	// columns: z
-	// 	.array(
-	// 		z.object({
-	// 			name: z.string(),
-	// 			linkField: z.string(),
-	// 			visible: z.boolean().optional(),
-	// 			minWidth: z.number().optional(),
-	// 		}),
-	// 	)
-	// 	.optional(),
 	menuSorter: z.number().optional(),
 	icon: z.string().optional(),
 	isPreference: z.boolean().optional(),

--- a/imports/model/Menu.ts
+++ b/imports/model/Menu.ts
@@ -5,16 +5,16 @@ export const MenuItemSchema = z.object({
 	name: z.string(),
 	type: z.string(),
 	document: z.string().optional(),
-	columns: z
-		.array(
-			z.object({
-				name: z.string(),
-				linkField: z.string(),
-				visible: z.boolean().optional(),
-				minWidth: z.number().optional(),
-			}),
-		)
-		.optional(),
+	// columns: z
+	// 	.array(
+	// 		z.object({
+	// 			name: z.string(),
+	// 			linkField: z.string(),
+	// 			visible: z.boolean().optional(),
+	// 			minWidth: z.number().optional(),
+	// 		}),
+	// 	)
+	// 	.optional(),
 	menuSorter: z.number().optional(),
 	icon: z.string().optional(),
 	isPreference: z.boolean().optional(),

--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -1,2 +1,3 @@
 import '/server/routes/api/translation';
 import '/server/routes/api/menu/main';
+import '/server/routes/api/list-view';

--- a/server/routes/api/list-view/index.ts
+++ b/server/routes/api/list-view/index.ts
@@ -1,0 +1,57 @@
+import { WebApp } from 'meteor/webapp';
+import { match } from 'path-to-regexp';
+import { getUserFromRequest } from '/imports/auth/getUser';
+import { logger } from '/imports/utils/logger';
+import { listView } from '/imports/list-view';
+
+WebApp.connectHandlers.use('/api/list-view', async (req, res) => {
+	const matchPath = match<{ document?: string; id?: string }>('/api/list-view/:document/:id', { decode: decodeURIComponent });
+
+	const urlParams = matchPath(req.originalUrl ?? '');
+
+	if (req.originalUrl == null || urlParams === false) {
+		res.writeHead(404);
+		res.end('Not found');
+		return;
+	}
+
+	const document = urlParams.params.document;
+	const id = urlParams.params.id;
+
+	if (document == null || id == null) {
+		res.writeHead(400);
+		res.end('Bad request');
+		return;
+	}
+
+	try {
+		const user = await getUserFromRequest(req);
+
+		if (user == null) {
+			res.writeHead(401);
+			res.end('Unauthorized');
+			return;
+		}
+
+		const result = await listView(document, id);
+
+		if (result == null) {
+			res.writeHead(404);
+			res.end('Not found');
+			return;
+		}
+
+		res.setHeader('Content-Type', 'application/json');
+		res.writeHead(200);
+		res.end(JSON.stringify(result, null, 2));
+	} catch (error) {
+		if (/^\[get-user\]/.test((error as Error).message)) {
+			res.writeHead(401);
+			res.end('Unauthorized');
+			return;
+		}
+		logger.error(error, `Error getting list view for test`);
+		res.writeHead(500);
+		res.end('Internal server error');
+	}
+});

--- a/server/routes/api/list-view/index.ts
+++ b/server/routes/api/list-view/index.ts
@@ -50,7 +50,7 @@ WebApp.connectHandlers.use('/api/list-view', async (req, res) => {
 			res.end('Unauthorized');
 			return;
 		}
-		logger.error(error, `Error getting list view for test`);
+		logger.error(error, `Error getting list view for ${document}/${id}}`);
 		res.writeHead(500);
 		res.end('Internal server error');
 	}


### PR DESCRIPTION

O retorno da rota ficou da seguinte maneira (exemplo do documento Product list Default):

```
{
  "_id": "Product:list:Default",
  "name": "Default",
  "document": "Product",
  "label": "Product",
  "plurals": "Products",
  "loadDataAtOpen": true,
  "columns": [
    {
      "name": "code",
      "linkField": "code",
      "visible": true,
      "minWidth": 60
    }
  ],
  "refreshRate": {
    "options": [0],
    "default": 0
  },
  "rowsPerPage": {
    "options": [5],
    "default": 25
  },
  "sorters": [
    {
      "term": "score",
      "direction": "desc"
    }
  ],
  "view": "Default"
}
```