### PR TITLE
Fix: watch metas when using builtin konsistent

### DIFF
--- a/src/imports/meta/loadMetaObjects.ts
+++ b/src/imports/meta/loadMetaObjects.ts
@@ -451,7 +451,6 @@ export async function loadMetaObjects() {
 	}
 	logger.info('Loading MetaObject.Meta from database');
 	await dbLoad();
-	if (MetaObject.Namespace?.plan?.useExternalKonsistent) {
-		dbWatch();
-	}
+
+	dbWatch();
 }


### PR DESCRIPTION
The MetaObjects collection wans't being watched if that Konecty instance was using the builtin Konsistent (as opposed to the external one). Removed the condition, so every plan can watch de database now.