### PR TITLE
Fix: Process value for name

### DIFF
--- a/src/imports/data/data.js
+++ b/src/imports/data/data.js
@@ -939,7 +939,7 @@ export async function create({ authTokenId, document, data, contextUser, upsert,
 		}
 	});
 
-	const validateAllFieldsResult = await BluebirdPromise.mapSeries(Object.entries(metaObject.fields), async ([key]) => {
+	const validateAllFieldsResult = await BluebirdPromise.mapSeries(Object.keys(metaObject.fields), async (key) => {
 		const value = cleanedData[key];
 		const result = await validateAndProcessValueFor({
 			meta: metaObject,

--- a/src/imports/meta/validateAndProcessValueFor.js
+++ b/src/imports/meta/validateAndProcessValueFor.js
@@ -625,7 +625,7 @@ export async function validateAndProcessValueFor({ meta, fieldName, value, actio
 					return acc;
 				}, {});
 
-				value.full = keys
+				value.full = value.full ?? keys
 					.map(key => value[key] ?? '')
 					.filter(v => v.length > 0)
 					.join(' ');


### PR DESCRIPTION
When parsing fields with type `personName`, it must resolve with a property `full` representing all name props combined:

1. If the property `full` is provided, use it
2. Otherwise, combine all other props **excluding** the full property

Previously it was concatenating all props, including the full, resulting in repeated names.