### PR TITLE
Fix: Don't remove inherited fields if it's sent on request

### DIFF
--- a/src/imports/meta/removeInheritedFields.js
+++ b/src/imports/meta/removeInheritedFields.js
@@ -1,9 +1,9 @@
 import isArray from 'lodash/isArray';
 
-export function removeInheritedFields(lookupField) {
+export function removeInheritedFields(lookupField, objectNewValues) {
 	if (isArray(lookupField.inheritedFields)) {
 		return lookupField.inheritedFields.reduce((acc, inheritedField) => {
-			if (['always', 'hierarchy_always'].includes(inheritedField.inherit)) {
+			if (['always', 'hierarchy_always'].includes(inheritedField.inherit) && objectNewValues[inheritedField.fieldName] === undefined) {
 				acc[inheritedField.fieldName] = null;
 			}
 			return acc;

--- a/src/imports/meta/validateAndProcessValueFor.js
+++ b/src/imports/meta/validateAndProcessValueFor.js
@@ -123,7 +123,7 @@ export async function validateAndProcessValueFor({ meta, fieldName, value, actio
 	}
 
 	if (actionType === 'update' && value == null && field.type === 'lookup') {
-		Object.assign(objectNewValues, removeInheritedFields(field));
+		Object.assign(objectNewValues, removeInheritedFields(field, objectNewValues));
 	}
 
 	if (value == null && field.type !== 'autoNumber') {


### PR DESCRIPTION
The current behaviour when removing a `lookup` field from a record (such as development on a Product) is to remove all `inheritedFields` from it.
The problem is that it removed all the fields even if it was assigned a value on the request as well.
This PR aims to fix it. Keep the fields that came from the request (or other sources, such as the `scriptBeforeValidation`).

Fixes #155 