### PR TITLE
Feat: Get any meta

### DIFF
--- a/src/imports/document/index.ts
+++ b/src/imports/document/index.ts
@@ -1,27 +1,34 @@
-import { DocumentSchema } from '../model/Document';
 import { MetaObject } from '@imports/model/MetaObject';
-import { MetaObjectType } from '@imports/types/metadata';
 import { logger } from '@imports/utils/logger';
+import { DocumentSchema } from '../model/Document';
 
-export async function getDocument(id: string) {
-	const document = await MetaObject.MetaObject.findOne<MetaObjectType>({ type: 'document', name: id, menuSorter: { $nin: [-1, -2, -3] } });
+export async function getDocument(id: string, type: keyof typeof MetaObject = 'Meta') {
+	const metaStore = MetaObject[type];
+	if (metaStore == null) {
+		throw new Error(`Meta store ${type} not found`);
+	}
 
-	if (document?.type != 'document') {
+	const document = metaStore[id as keyof typeof metaStore];
+	if (document == null) {
 		throw new Error(`Document ${id} not found`);
 	}
 
-	const getDocumentResult = DocumentSchema.safeParse(document);
+	if (type === 'Meta') {
+		const getDocumentResult = DocumentSchema.safeParse(document);
 
-	if (getDocumentResult.success === false) {
-		logger.error(
-			{
-				form: document,
-				error: getDocumentResult.error,
-			},
-			`Error parsing document ${id}`,
-		);
-		return null;
+		if (getDocumentResult.success === false) {
+			logger.error(
+				{
+					form: document,
+					error: getDocumentResult.error,
+				},
+				`Error parsing document ${id}`,
+			);
+			return null;
+		}
+
+		return getDocumentResult.data;
 	}
 
-	return getDocumentResult.data;
+	return document;
 }

--- a/src/server/routes/api/document/index.ts
+++ b/src/server/routes/api/document/index.ts
@@ -3,14 +3,14 @@ import fp from 'fastify-plugin';
 
 import { getUserFromRequest } from '@imports/auth/getUser';
 import { getDocument } from '@imports/document';
-import { logger } from '@imports/utils/logger';
-import { WithoutId } from 'mongodb';
 import { loadMetaObjects } from '@imports/meta/loadMetaObjects';
 import { MetaObject } from '@imports/model/MetaObject';
 import { MetaObjectSchema, MetaObjectType } from '@imports/types/metadata';
+import { logger } from '@imports/utils/logger';
+import { WithoutId } from 'mongodb';
 
 const documentAPi: FastifyPluginCallback = async fastify => {
-	fastify.get<{ Params: { name: string } }>('/api/document/:name', async (req, reply) => {
+	fastify.get<{ Params: { name: string }; Querystring: { type?: keyof typeof MetaObject } }>('/api/document/:name', async (req, reply) => {
 		if (req.originalUrl == null || req.params == null) {
 			return reply.status(404).send('Not found');
 		}
@@ -28,7 +28,7 @@ const documentAPi: FastifyPluginCallback = async fastify => {
 				return reply.status(401).send('Unauthorized');
 			}
 
-			const result = await getDocument(name);
+			const result = await getDocument(name, req.query.type);
 
 			if (result == null) {
 				return reply.status(404).send('Invalid meta object');


### PR DESCRIPTION
- Mudando a rota de get document para permitir um `queryString type`, direcionando que tipo de documento foi pedido.
- Ao invés de buscar o documento no banco, retorna os que já estão processados em memória. São os mesmos documentos usado em toda aplicação.
- O parametro `type` corresponde à key do MetaObjects
- O comportamentro padrão da rota continua o mesmo, mas tem a opção de buscar outros tipos de metas agora, por exemplo access ou views