### PR TITLE
feat: add descriptionFields labels

### DIFF
--- a/src/imports/lib/buildI18N/index.ts
+++ b/src/imports/lib/buildI18N/index.ts
@@ -6,6 +6,8 @@ import { MetaObject } from '../../model/MetaObject';
 import { User } from '../../model/User';
 import { MetaObjectType } from '../../types/metadata';
 import { getAccessFor } from '../../utils/accessUtils';
+import { Field } from '@imports/model/Field';
+
 const negative: Label = {
 	en: 'Not',
 	de: 'Nicht',
@@ -78,11 +80,43 @@ export const buildI18N = async (user: User): Promise<Record<string, unknown>> =>
 						const label = get(fieldLabel, 'label');
 						const options = get(fieldLabel, 'options');
 						const type = get(fieldLabel, 'type');
-						if (metaProp === 'fields' && options != null) {
-							Object.entries(options).forEach(entry => {
-								const [option, optionLabels] = entry as [string, Label];
-								Object.entries(optionLabels).forEach(([lang, value]) => set(acc, [fixISO(lang), ...keyPath, 'options', field, option], value as string));
-							});
+						if (metaProp === 'fields') {
+							if (options != null) {
+								Object.entries(options).forEach(entry => {
+									const [option, optionLabels] = entry as [string, Label];
+									Object.entries(optionLabels).forEach(([lang, value]) => set(acc, [fixISO(lang), ...keyPath, 'options', field, option], value as string));
+								});
+							}
+							if (type === "lookup") {
+								const findLookupSubField: (lookup: {document: string, name: string}) => Field | null = ({document, name}) => {
+									if(name.includes('.')) {
+										const [subField, ... fieldParts] = name.split('.');
+										const subFieldDoc = findLookupSubField({document, name: subField});
+										return findLookupSubField({document: subFieldDoc?.document ?? '', name: fieldParts.join('.')});
+									}
+									const lookupMeta = metas.find(meta => meta.name === document) ?? {};
+									const subFieldLabel = get(lookupMeta, `fields.${name}`, null);
+									return subFieldLabel as Field | null;
+								}
+								const fieldDocument = get(fieldLabel, 'document');
+								const descriptionFields = get(fieldLabel, 'descriptionFields', []) as string[];
+								const recursiveDescriptionFields = descriptionFields.reduce((acc, field) => {
+									const fieldParts = field.split('.');
+									const recursiveParts = fieldParts.map((part, index) => fieldParts.slice(0, index + 1).join('.'));
+									return [...acc, ...recursiveParts];
+								}, [] as string[]);
+								if (fieldDocument != null && Array.isArray(recursiveDescriptionFields)) {
+									recursiveDescriptionFields.forEach(subField => {
+										const subFieldLabel = findLookupSubField({document: fieldDocument, name: subField});
+										if(subFieldLabel != null) {
+											const label: Label = get(subFieldLabel, 'label', {});
+											Object.entries(label).forEach(([lang, value]) => set(acc, [fixISO(lang), ...keyPath, 'fields', `${field}.${subField}`], value as string));
+										}
+									});
+								}
+							}
+
+							
 						}
 						if (label != null) {
 							Object.entries(label).forEach(([lang, value]) => {


### PR DESCRIPTION
Adiciona labels dos campos descriptionFields de lookups ao documento, pois o usuário pode não ter acesso ao módulo e nesse caso fica sem os rótulos disponíveis na interface.
<img width="620" alt="Screenshot 2025-01-16 at 17 43 15" src="https://github.com/user-attachments/assets/0f52c775-e56c-43e5-a90c-8b311143995d" />
