### PR TITLE
Fix: handle common Mongo errors & display friendly

### DIFF
--- a/src/imports/data/data.js
+++ b/src/imports/data/data.js
@@ -37,6 +37,7 @@ import { find } from "@imports/data/api";
 import { client } from '@imports/database';
 import { Konsistent } from '@imports/konsistent';
 import eventManager from '@imports/lib/EventManager';
+import { handleCommonMongoError } from '@imports/utils/mongo';
 import { dateToString, stringToDate } from '../data/dateParser';
 import { populateLookupsData } from '../data/populateLookupsData';
 import { processCollectionLogin } from '../data/processCollectionLogin';
@@ -819,6 +820,10 @@ export async function create({ authTokenId, document, data, contextUser, upsert,
 					}
 				} catch (e) {
 					await handleTransactionError(e, dbSession);
+					const mongoErrorResult = handleCommonMongoError(e, document);
+					if (mongoErrorResult.success === false) {
+						return mongoErrorResult;
+					}
 
 					logger.error(e, `Error on insert ${MetaObject.Namespace.ns}.${document}: ${e.message}`);
 					tracingSpan?.addEvent('Error on insert', { error: e.message });
@@ -1325,6 +1330,10 @@ export async function update({ authTokenId, document, data, contextUser, tracing
 					return successReturn({ _id: record._id, ...bodyData });
 				} catch (e) {
 					await handleTransactionError(e, dbSession);
+					const mongoErrorResult = handleCommonMongoError(e, document);
+					if (mongoErrorResult.success === false) {
+						return mongoErrorResult;
+					}
 
 					logger.error(e, `Error updating record ${MetaObject.Namespace.ns}.${document}: ${e.message}`);
 					tracingSpan?.addEvent('Error updating record', { error: e.message });

--- a/src/imports/meta/metaUtils.ts
+++ b/src/imports/meta/metaUtils.ts
@@ -1,0 +1,4 @@
+export function getLabel<T extends { label?: Record<string, string>; name?: string }>(withLabel: T, lang?: string): string {
+	const language = lang || 'pt_BR';
+	return withLabel.label?.[language] ?? withLabel.label?.en ?? withLabel.name ?? '';
+}

--- a/src/imports/model/Document/index.ts
+++ b/src/imports/model/Document/index.ts
@@ -23,6 +23,7 @@ export const DocumentSchema = z
 			.record(
 				z.object({
 					keys: z.record(z.string(), z.union([z.number(), z.boolean()])),
+					label: LabelSchema.optional(),
 					options: z.object({
 						name: z.string().optional(),
 						unique: z.boolean().optional(),

--- a/src/imports/utils/mongo.ts
+++ b/src/imports/utils/mongo.ts
@@ -1,8 +1,12 @@
 import { db } from '@imports/database';
+import { getLabel } from '@imports/meta/metaUtils';
+import { MetaObject } from '@imports/model/MetaObject';
+import { KonectyResult } from '@imports/types/result';
 import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import { MongoServerError, ObjectId } from 'mongodb';
 import { logger } from './logger';
+import { errorReturn, successReturn } from './return';
 
 export function convertObjectIds<T>(
 	records: T,
@@ -43,4 +47,66 @@ export async function isReplicaSet() {
 		logger.error('Erro ao verificar status do replica set:', error);
 		return false;
 	}
+}
+
+/**
+ * Handles common MongoDB errors and converts them into a standardized KonectyResult object.
+ * @param error - The error object to handle
+ * @returns A KonectyResult object with appropriate error messages for common MongoDB errors
+ */
+export function handleCommonMongoError(error: unknown, documentName: string): KonectyResult {
+	// If not a MongoDB error, return success
+	if (!(error instanceof MongoServerError)) {
+		return successReturn(null);
+	}
+
+	const mongoError = error as MongoServerError;
+
+	try {
+		switch (mongoError.code) {
+			case 11000:
+				const { name, fields } = getIndexInfo(mongoError.message);
+				if (fields.length === 1) {
+					const indexField = MetaObject.Meta[documentName].fields[fields[0]];
+					if (indexField) {
+						return errorReturn(`[${documentName}] O campo ${getLabel(indexField)} deve ser único mas já existe com esse valor.`);
+					}
+				}
+				const metaIndexes = MetaObject.Meta[documentName].indexes;
+				if (metaIndexes) {
+					const index = Object.entries(metaIndexes).find(([idxKey, index]) => [index.options?.name, idxKey].includes(name));
+					if (index) {
+						const helpText = getLabel(index[1]) || `Validação de dados únicos violada: ${name}`;
+						return errorReturn(`[${documentName}] ${helpText}`);
+					}
+				}
+				return errorReturn(`[${documentName}] Validação de dados únicos violada: ${name}`);
+
+			case 50:
+				return errorReturn(`[${documentName}] Operação demorou mais que o esperado. Caso o problema persista, contate o suporte.`);
+
+			case 91:
+				return errorReturn(`[${documentName}] Servidor desligando. Caso o problema persista, contate o suporte.`);
+		}
+	} catch (error) {}
+
+	logger.error(error, `Unexpected Mongo operation error: ${mongoError.message}`);
+	return errorReturn(`[${documentName}] Erro ao processar a operação. Caso o problema persista, contate o suporte.`);
+}
+
+function getIndexInfo(errorMessage: string): { name: string; fields: string[] } {
+	const indexRegex = /index:\s+(\w+)\s+dup key:\s+({[^}]+})/;
+	const matches = errorMessage.match(indexRegex);
+
+	if (!matches) {
+		throw new Error('Could not parse index information from error message');
+	}
+
+	const [, indexName, dupKeyStr] = matches;
+	const dupKey = JSON.parse(dupKeyStr.replace(/([{,]\s*)([^":\s]+):/g, '$1"$2":'));
+
+	return {
+		name: indexName,
+		fields: Object.keys(dupKey),
+	};
 }


### PR DESCRIPTION
A algum tempo que precisamos melhorar as mensagens de error para que tenham algum significado para os usuários comuns. Tratamos alguns erros comuns, como timeout e server shutdown, além do erro de maior ocorrência, Duplicate key error (ao tentar criar valores já existentes com indice único).

- Erro em campos marcados como `isUnique`:
<img width="837" alt="Screenshot 2025-03-10 at 19 07 35" src="https://github.com/user-attachments/assets/2265ea6a-12b2-426e-9578-88ad3a6857d2" />
<br/><br/>

- Erro em índices explícitos que possuem apenas nome:
<img width="784" alt="Screenshot 2025-03-10 at 19 09 51" src="https://github.com/user-attachments/assets/988ed978-2eb4-4e2a-99bd-aa9edd0feb42" />
<br/><br/>

- **NOVO** Erro em índices explícitos com mensagem de ajuda:
<img width="586" alt="Screenshot 2025-03-10 at 19 10 47" src="https://github.com/user-attachments/assets/5f567a70-a67c-41e6-ad60-6c8d74ee4898" />

<br/>
Closes #224 