### PR TITLE
Fix: add timeout to send email

### DIFF
--- a/src/imports/utils/timeout.ts
+++ b/src/imports/utils/timeout.ts
@@ -1,0 +1,7 @@
+export async function withTimeout<T>(promise: Promise<T> | (() => Promise<T>), timeout: number, operationName: string): Promise<T> {
+	if (typeof promise === 'function') {
+		promise = promise();
+	}
+	const result = await Promise.race([promise, new Promise((_, reject) => setTimeout(() => reject(new Error(`${operationName} timed out after ${timeout}ms`)), timeout))]);
+	return result as T;
+}


### PR DESCRIPTION
É bem possível que o envio de email pelo NodeMailer esteja ficando pendurado indefinidamente. 
- Coloquei um log antes do envio de email para ter certeza
- Adicionei um timeout (30s padrao) para cada email enviar, se não marca como falha
- Não há impactos no uso atual, contanto que os email enviem mais rápido do que 30s