### PR TITLE
feat: add dual-shell UI proxy support with environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Copy to .env and adjust. Never commit real secrets.
+
+# Port where THIS Konecty process listens (e.g. 3000).
+PORT=3000
+
+# Legacy Ext UI asset host (startup.js, resources) - used by index.hbs as //{{host}}/...
+# Never set this to Konecty itself (e.g. localhost:3000): those paths are not served by the API and you get 404 + stuck loading.
+UI_URL=https://feat-duplicate-prop.konecty-legacy-ui.pages.dev
+
+# Dual shell: legacy HTML at /, React gestor under UI_PROXY_PATH.
+# UI_PROXY_URL must be the base URL of the Vite / SPA dev server (see `yarn start` in repo ui), NOT Konecty.
+# Example: Konecty on :3000 and Vite on :3001 -> UI_PROXY_URL=http://localhost:3001
+# Build/deploy the React app with BASE_URL=/ui/ when using UI_PROXY_PATH=/ui.
+UI_PROXY_PATH=/ui
+UI_PROXY_URL=http://localhost:3001
+
+# Path used by "Nova interface" when staying on the Konecty host (relative). Default matches UI_PROXY_PATH (e.g. /ui/).
+# In development, if UI_NEW_UI_BROWSER_PATH is unset and UI_PROXY_URL is http(s), "Nova interface" opens that URL (e.g. http://localhost:3001/).
+# Set UI_NEW_UI_BROWSER_PATH=/ui/ to force same-origin /ui/ on localhost even in dev.
+# Absolute URL also works: UI_NEW_UI_BROWSER_PATH=http://localhost:3001/
+# UI_NEW_UI_BROWSER_PATH=/ui/
+
+# Leave unset so Konecty serves legacy shell at /. Setting UI_PROXY=true proxies ALL GET / to UI_PROXY_URL and disables viewPaths.
+# UI_PROXY=true
+
+ALLOWED_ORIGINS=http://localhost:3000|http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ This will watch the Tailwind input file and regenerate CSS automatically when yo
 -   `DEFAULT_SMTP_TLS_REJECT_UNAUTHORIZED`: SMTP config `tls.rejectUnauthorized` for nodemailer, config would open a connection to TLS server with self-signed or invalid TLS certificate
 -   `DEFAULT_SMTP_AUTH_METHOD`: SMTP config `authMethod` for nodemailer, defines preferred authentication method, defaults to 'PLAIN'
 -   `DEFAULT_SMTP_DEBUG`: SMTP config `debug` for nodemailer, if set to true, then logs SMTP traffic, otherwise logs only transaction events
--   `UI_URL`: host for ui
+-   `UI_URL`: host serving the **legacy Ext UI** assets referenced by `index.hbs` / login templates (`startup.js`, resources, ...)
+-   `UI_PROXY`: (optional) `true` proxies **all** `GET` HTML traffic to `UI_PROXY_URL` and skips Konecty shell routes (`/` login pages). Prefer leaving this unset when serving legacy at `/` and the React gestor only under `UI_PROXY_PATH`.
+-   `UI_PROXY_URL`: upstream origin for the **React gestor** SPA when proxied (e.g. Cloudflare Pages host). Build that SPA with `BASE_URL=/ui/` when using `UI_PROXY_PATH=/ui`.
+-   `UI_PROXY_PATH`: mount path for the SPA proxy (e.g. `/ui`). Requires `UI_PROXY_URL`. Strip trailing slashes in env values.
+-   `UI_NEW_UI_BROWSER_PATH`: (optional) Where the browser opens the React gestor. **Relative** paths (e.g. `/ui/`) stay on the Konecty host. **Absolute** `http(s)://...` forces that URL. If unset in **`KONECTY_MODE=development`** and `UI_PROXY_URL` is `http(s)://...`, "Nova interface" opens `UI_PROXY_URL` directly (typical local Vite on `:3001`). Set `UI_NEW_UI_BROWSER_PATH=/ui/` to keep `localhost:3000/ui/` in dev. Production keeps same-origin `/ui/` when this is unset and mode is not development.
 -   `LOG_LEVEL`: [Pino log levels](https://github.com/pinojs/pino/blob/HEAD/docs/api.md#level-string)
 -   `LOG_TO_FILE`: Optional file name to write all logs. Path relative to project root
 -   `DISABLE_SENDMAIL`: (optional) `true` to disable email processing

--- a/docs/changelog/2026-04-30_dual-shell-ui-proxy-legado-react.md
+++ b/docs/changelog/2026-04-30_dual-shell-ui-proxy-legado-react.md
@@ -1,0 +1,14 @@
+# Changelog — Alternância entre interface clássica (Ext) e nova (React)
+
+- **Summary:** Preferência explícita (`new` / `legacy`) persistida em `localStorage`, sincronizada por query string ao cruzar origens, com CTAs claros no shell legado (“Experimente a nova interface”) e navegação configurável para abrir o gestor React em mesma origem (`/ui/`) ou URL absoluta em desenvolvimento; infraestrutura no Konecty serve Ext em `/` e o SPA novo sob `UI_PROXY_PATH`.
+- **Motivation:** Usuários e desenvolvedores precisam alternar entre o shell Ext legado e o gestor React sem loop de redirect entre `:3000` e `:3001`, com uma única fonte de verdade para a escolha de interface e sem substituir toda a raiz do site quando só o gestor novo deve ficar montado em `/ui`.
+- **What changed:**
+  - **`index.hbs`:** leitura/gravação da preferência (`konecty-ui-version`), sync via `konectyUiShell` na URL (aplica `new`/`legacy`, remove o parâmetro), bootstrap de redirect quando a preferência é “nova” na landing `/`, injeção do CTA ao lado do usuário antes do split de bundles remotos.
+  - **`view.ts`:** destino do link “nova interface” respeita `UI_NEW_UI_BROWSER_PATH` e, em desenvolvimento com `UI_PROXY_URL` HTTP(S), pode abrir diretamente o dev server do gestor quando não há override.
+  - **`routes/index.ts`:** proxy GET/HEAD do SPA apenas em `UI_PROXY_PATH` com `rewritePrefix: '/'`; modo `UI_PROXY=true` permanece opcional para quem quer proxy total da raiz; CORS inclui a origem do gestor quando configurada.
+  - **`.env.example` / `README`:** documentação das variáveis do modo dual-shell (`UI_PROXY_PATH`, `UI_PROXY_URL`, `UI_NEW_UI_BROWSER_PATH`, `ALLOWED_ORIGINS`).
+- **Technical impact:** APIs permanecem no Konecty; o gestor React é servido por proxy ou build estático conforme deploy, sempre com caminho de montagem previsível para `BASE_URL=/ui/`.
+- **External impact:** Fluxo visível de experimentação da nova interface a partir do legado e retorno ao clássico pela nova UI (implementado no repo `ui`), com preferência estável entre reloads.
+- **How to validate:** Com dual-shell ativo, na interface legada usar o CTA e confirmar abertura do gestor conforme env; alternar preferência e recarregar sem loop; opcionalmente validar query `?konectyUiShell=new|legacy` aplicando a escolha e limpando a URL.
+- **Affected files:** `src/private/templates/index.hbs`, `src/server/routes/rest/view/view.ts`, `src/server/routes/index.ts`, `.env.example`, `README.md`, `docs/changelog/2026-04-30_dual-shell-ui-proxy-legado-react.md`, `docs/changelog/README.md`
+- **Migration required?** Não. Adotar dual-shell implica configurar env no deploy conforme documentado.

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -4,6 +4,7 @@ Registro de alterações relevantes do projeto. Cada entrada segue o formato `YY
 
 ## Entradas
 
+- [2026-04-30 — Alternância interface clássica / nova: preferência, query, CTA no legado, dual-shell](./2026-04-30_dual-shell-ui-proxy-legado-react.md)
 - [2026-04-27 — SFTP: hash+ext, delete na rota estilo 144fe0d, basename real e variantes no `SFTPStorage`, fim de `resolveUploadBaseName`](./2026-04-27_refactor-sftp-file-upload-delete.md)
 - [2026-04-16 — Storage SFTP (Namespace), resolução de delete, erros de upload e nomes Office](./2026-04-16_sftp-storage-file-upload-delete.md)
 - [2026-03-26 — findByLookup: conditionFields no metadata do lookup](./2026-03-26_findbylookup-conditionfields.md)
@@ -26,6 +27,7 @@ Entries are in `docs/changelog/` as `YYYY-MM-DD_slug.md`.
 
 | Date       | Slug                        | Summary |
 |-----------|-----------------------------|--------|
+| 2026-04-30 | dual-shell-ui-proxy-legado-react | Preferência new/legacy (`localStorage` + query), CTAs e bootstrap no `index.hbs`; proxy `/ui` e env dual-shell |
 | 2026-04-27 | refactor-sftp-file-upload-delete | MD5+ext no upload; delete simples na rota; SFTP apaga por basename real + variantes; fim de `resolveUploadBaseName` |
 | 2026-04-16 | sftp-storage-file-upload-delete | Storage SFTP via Namespace, delete pela `key`, basename Office, erros estruturados no upload |
 | 2026-03-26 | findbylookup-conditionfields | Apply lookup field conditionFields in findByLookup MongoDB filter |

--- a/src/private/templates/index.hbs
+++ b/src/private/templates/index.hbs
@@ -84,7 +84,66 @@
 			<script src='/fp.js'></script>
 		{{/if}}
 		<script type='text/javascript'>
-			window.BLOB_URL = '{{blobUrl}}'; window.PREVIEW_URL = '{{previewUrl}}'; window.LOCALE = '{{locale}}'; window.ENV = ''; window.HOST = '{{host}}'; window.UI_URL = '{{uiServer}}';
+			window.BLOB_URL = '{{blobUrl}}';
+			window.PREVIEW_URL = '{{previewUrl}}';
+			window.LOCALE = '{{locale}}';
+			window.ENV = '';
+			window.HOST = '{{host}}';
+			window.UI_URL = '{{uiServer}}';
+			window.KONECTY_NEW_UI_ABSOLUTE = '{{newUiAbsoluteBase}}';
+			window.KONECTY_NEW_UI_PATH = '{{newUiBrowserPath}}';
+			window.konectyOpenNewUiShell = function (useReplace) {
+				try {
+					localStorage.setItem('konecty-ui-version', 'new');
+				} catch (e) {}
+				var abs = (window.KONECTY_NEW_UI_ABSOLUTE || '').trim();
+				var rel = typeof window.KONECTY_NEW_UI_PATH === 'string' ? window.KONECTY_NEW_UI_PATH : '/ui/';
+				var url;
+				if (abs) {
+					url = new URL(abs);
+				} else {
+					url = new URL(rel, window.location.origin);
+				}
+				url.search = window.location.search;
+				url.hash = window.location.hash;
+				if (abs) {
+					url.searchParams.set('konectyUiShell', 'new');
+				}
+				if (useReplace) {
+					window.location.replace(url.href);
+				} else {
+					window.location.href = url.href;
+				}
+			};
+		</script>
+		<script>
+			(function () {
+				try {
+					var params = new URLSearchParams(window.location.search);
+					var shellPref = params.get('konectyUiShell');
+					if (shellPref === 'new') {
+						localStorage.setItem('konecty-ui-version', 'new');
+					} else if (shellPref === 'legacy') {
+						localStorage.setItem('konecty-ui-version', 'legacy');
+					} else {
+						return;
+					}
+					params.delete('konectyUiShell');
+					var qs = params.toString();
+					history.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : '') + window.location.hash);
+				} catch (err) {}
+			})();
+		</script>
+		<script>
+			(function () {
+				try {
+					if (localStorage.getItem('konecty-ui-version') !== 'new') return;
+					var path = window.location.pathname || '';
+					if (path !== '/' && path !== '') return;
+					if (typeof window.konectyOpenNewUiShell !== 'function') return;
+					window.konectyOpenNewUiShell(true);
+				} catch (e) {}
+			})();
 		</script>
 	</head>
 	<body>
@@ -129,5 +188,120 @@
 		></script>
 		<script src='//{{uiServer}}/resources/jquery.magnific-popup.js'></script>
 		<script type='text/javascript' src='//{{uiServer}}/startup.js?_dc={{timeInMilis}}'></script>
+		<script>
+			(function () {
+				var mounted = false;
+				var observer = null;
+
+				function disconnectObserver() {
+					if (observer) {
+						observer.disconnect();
+						observer = null;
+					}
+				}
+
+				function ensureStyle() {
+					if (document.getElementById('konecty-new-ui-shell-style')) return;
+					var style = document.createElement('style');
+					style.id = 'konecty-new-ui-shell-style';
+					style.textContent =
+						'.k-new-ui-shell-cta{margin-right:8px!important;border-radius:999px!important;border:1px solid #b7d4f6!important;background:#f4f9ff!important;box-shadow:none!important;}' +
+						'.k-new-ui-shell-cta .x-btn-inner{padding:0 9px!important;}' +
+						'.k-ui-shell-cta-content{display:inline-flex;align-items:center;height:22px;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}' +
+						'.k-ui-shell-cta-label{font-size:11px;font-weight:600;color:#1f5f9f;white-space:nowrap;}';
+					document.head.appendChild(style);
+				}
+
+				function getCtaText() {
+					return '<span class="k-ui-shell-cta-content"><span class="k-ui-shell-cta-label">Experimente a nova interface</span></span>';
+				}
+
+				function openNewUi() {
+					var abs = (window.KONECTY_NEW_UI_ABSOLUTE || '').trim();
+					var rel = typeof window.KONECTY_NEW_UI_PATH === 'string' ? window.KONECTY_NEW_UI_PATH : '/ui/';
+					var previewHref = abs ? abs : new URL(rel, window.location.origin).href;
+					if (typeof window.konectyOpenNewUiShell === 'function') {
+						window.konectyOpenNewUiShell(false);
+					} else {
+						window.location.href = previewHref;
+					}
+				}
+
+				function buildButtonConfig() {
+					return {
+						xtype: 'button',
+						scale: 'small',
+						ui: 'header',
+						itemId: 'btnNewUiShell',
+						cls: 'k-new-ui-shell-cta',
+						text: getCtaText(),
+						tooltip: 'Abrir a nova interface do gestor',
+						handler: openNewUi,
+					};
+				}
+
+				function tryMountInHeader() {
+					if (mounted) {
+						return true;
+					}
+					if (!window.Ext || !Ext.ComponentQuery) {
+						return false;
+					}
+					try {
+						var users = Ext.ComponentQuery.query('viewportheader #btnUser');
+						if (!users.length) {
+							return false;
+						}
+						var userBtn = users[0];
+						var header = userBtn.up && userBtn.up('viewportheader');
+						if (!header || !header.items) {
+							return false;
+						}
+						var userIndex = header.items.indexOf(userBtn);
+						if (userIndex < 0) {
+							return false;
+						}
+						ensureStyle();
+						var existing = Ext.ComponentQuery.query('viewportheader #btnNewUiShell')[0];
+						if (existing) {
+							existing.addCls && existing.addCls('k-new-ui-shell-cta');
+							existing.setText && existing.setText(getCtaText());
+							existing.setTooltip && existing.setTooltip('Abrir a nova interface do gestor');
+							if (existing.ownerCt === header) {
+								var existingIndex = header.items.indexOf(existing);
+								if (existingIndex !== userIndex - 1) {
+									header.remove(existing, false);
+									header.insert(existingIndex < userIndex ? userIndex - 1 : userIndex, existing);
+								}
+							}
+							header.doLayout && header.doLayout();
+							mounted = true;
+							disconnectObserver();
+							return true;
+						}
+						header.insert(userIndex, buildButtonConfig());
+						header.doLayout && header.doLayout();
+						mounted = true;
+						disconnectObserver();
+						return true;
+					} catch (err) {
+						return false;
+					}
+				}
+
+				function scheduleTick() {
+					if (tryMountInHeader()) {
+						return;
+					}
+					requestAnimationFrame(tryMountInHeader);
+				}
+
+				scheduleTick();
+				try {
+					observer = new MutationObserver(scheduleTick);
+					observer.observe(document.documentElement, { childList: true, subtree: true });
+				} catch (e) {}
+			})();
+		</script>
 	</body>
 </html>

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -106,19 +106,15 @@ if (process.env.UI_PROXY === 'true') {
 } else {
 	fastify.register(viewPaths);
 }
-if (process.env.UI_PROXY_PATH && process.env.UI_PROXY_URL) {
+
+const uiProxyPath = process.env.UI_PROXY_PATH?.replace(/\/$/, '') ?? '';
+if (uiProxyPath !== '' && process.env.UI_PROXY_URL) {
 	fastify.register(proxy, {
 		upstream: process.env.UI_PROXY_URL,
 		httpMethods: ['GET', 'HEAD'],
-		prefix: `${process.env.UI_PROXY_PATH}:path`,
-		rewritePrefix: ':path',
+		prefix: uiProxyPath,
+		rewritePrefix: '/',
 		disableRequestLogging: true,
-		replyOptions: {
-			onResponse: (request, reply) => {
-				const proxyUrl = `${process.env.UI_PROXY_URL}${request.url?.replace('/ui', '')}`;
-				reply.from(proxyUrl);
-			},
-		},
 	});
 }
 fastify.register(healthApi);

--- a/src/server/routes/rest/view/view.ts
+++ b/src/server/routes/rest/view/view.ts
@@ -30,6 +30,53 @@ const getEnv = () => {
 	return '';
 };
 
+function isAbsoluteHttpUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value.trim());
+}
+
+function withTrailingSlash(url: string): string {
+	const t = url.trim().replace(/\/+$/, '');
+	return t === '' ? '/' : `${t}/`;
+}
+
+function defaultRelativePathFromProxy(): string {
+	const proxyPath = process.env.UI_PROXY_PATH?.trim().replace(/\/$/, '') ?? '';
+	if (proxyPath !== '') {
+		const normalized = proxyPath.startsWith('/') ? proxyPath : `/${proxyPath}`;
+		return `${normalized}/`;
+	}
+	return '/ui/';
+}
+
+/**
+ * Where the browser should open the React gestor.
+ * - relativePath: same-origin path (UI_PROXY_PATH or /ui/).
+ * - absoluteBase: full origin+optional path when dev should jump straight to Vite (UI_PROXY_URL) or UI_NEW_UI_BROWSER_PATH is http(s).
+ */
+function getNewUiShellNavigation(): { absoluteBase: string; relativePath: string } {
+	const explicit = process.env.UI_NEW_UI_BROWSER_PATH?.trim();
+	const defaultRelative = defaultRelativePathFromProxy();
+
+	if (explicit && isAbsoluteHttpUrl(explicit)) {
+		return { absoluteBase: withTrailingSlash(explicit), relativePath: defaultRelative };
+	}
+
+	let relativePath = defaultRelative;
+	if (explicit && explicit.startsWith('/')) {
+		relativePath = explicit.endsWith('/') ? explicit : `${explicit}/`;
+	}
+
+	let absoluteBase = '';
+	if (!explicit && process.env.KONECTY_MODE === 'development') {
+		const proxyUrl = process.env.UI_PROXY_URL?.trim();
+		if (proxyUrl && isAbsoluteHttpUrl(proxyUrl)) {
+			absoluteBase = withTrailingSlash(proxyUrl);
+		}
+	}
+
+	return { absoluteBase, relativePath };
+}
+
 // Configuration priority: Namespace → env vars → defaults
 function getLoginPageVariant(): string {
 	const namespaceValue = MetaObject.Namespace.loginPageVariant;
@@ -298,6 +345,7 @@ export const viewPaths: FastifyPluginCallback = async fastify => {
 				return reply.redirect('/login');
 			}
 
+			const newUiNav = getNewUiShellNavigation();
 			const config = {
 				env: getEnv(),
 				host: getServer(process.env.KONECTY_HOST) || 'my.konecty.com',
@@ -306,6 +354,8 @@ export const viewPaths: FastifyPluginCallback = async fastify => {
 				btn_close: 'Fechar',
 				timeInMilis: +new Date(),
 				uiServer: getServer(process.env.UI_URL) || 'ui.konecty.com',
+				newUiAbsoluteBase: newUiNav.absoluteBase,
+				newUiBrowserPath: newUiNav.relativePath,
 				blobUrl: process.env.BLOB_URL == null ? '' : `//${getServer(process.env.BLOB_URL)}`,
 				previewUrl: process.env.PREVIEW_URL == null ? '' : `//${getServer(process.env.PREVIEW_URL)}`,
 				collectFingerprint: MetaObject.Namespace.trackUserFingerprint,


### PR DESCRIPTION
- Introduced a new `.env.example` file to document environment variables for dual-shell UI support, including `UI_PROXY_PATH`, `UI_PROXY_URL`, and `UI_NEW_UI_BROWSER_PATH`.
- Updated `README.md` to clarify the purpose of `UI_URL`, `UI_PROXY`, `UI_PROXY_URL`, and `UI_PROXY_PATH` in the context of serving legacy and new UI interfaces.
- Enhanced `index.hbs` to manage user interface preferences and navigation between legacy and new UI, including local storage handling for user preferences.
- Implemented proxy routing in `index.ts` to facilitate the new UI under specified paths, ensuring seamless integration with existing routes.
- Added a changelog entry documenting the dual-shell UI proxy feature and its configuration requirements.